### PR TITLE
Fix headings

### DIFF
--- a/binary-trees.md
+++ b/binary-trees.md
@@ -11,7 +11,7 @@
 * [Problem 60](p/p60.md) - Generate height-balanced trees with a give number of nodes. 
 
 ---
-###Traverse a Tree
+### Traverse a Tree
 Solving these three tree traversal problems will make it easier to solve the rest of the tree challenges
 
 * [Problem 68a](p/p68a.md) - Extract a list of nodes of a tree in pre-order. 

--- a/graphs.md
+++ b/graphs.md
@@ -19,7 +19,7 @@ We call this edge-clause form. The edge-clause cannot represent isolated nodes.
 
 ---
 
-##Graph-term form
+## Graph-term form
 
 To represent the whole graph we can use as a pair of sets (nodes and edges).
 
@@ -39,7 +39,7 @@ We call this the graph-term form. It will be our default representation in these
 
 ---
 
-##Adjancency list form
+## Adjancency list form
 A third representation method is to associate with each node the set of nodes that are adjacent to that node. We call this the adjacency-list form. In our example:
 
 ```elm
@@ -55,7 +55,7 @@ adjList80 =
 ```
 ---
 
-##Human-readable form
+## Human-readable form
 
 Typing the terms by hand is cumbersome and error-prone. We can define a more compact and "human-readable" notation as follows:
 
@@ -65,7 +65,7 @@ hm80 = "[b-c, f-c, g-h, d, f-b, k-f, h-g]"
 We call this the human-friendly form. The list does not have to be sorted and may even contain the same edge multiple times. Notice the isolated node d. Unlike the Graph and AdjList type, this is textual representation, not a type. 
 
 ---
-##Directed Graphs
+## Directed Graphs
 
 When the edges are directed we call them arcs. These are represented by ordered pairs. Such a graph is called directed graph. We can reuse the graph notation with little or no change, to represent digraphs. 
 
@@ -99,7 +99,7 @@ hrDigraph80 = "[s > r, t, u > r, s > u, u > s, v > u]"
 ```
 
 ---
-##Labeled graphs
+## Labeled graphs
 Finally, graphs and digraphs may have additional information attached to nodes and edges (arcs). For edges and arc we have to extend our notation. Graphs with additional information attached to edges are called labeled graphs.
 
 ![](i/graph3.gif)

--- a/lists-tuples-and-union-types.md
+++ b/lists-tuples-and-union-types.md
@@ -1,6 +1,6 @@
 # Lists and Tuples
 
-##What's a Tuple
+## What's a Tuple
 A Tuple is a fixed length collection of elements. Unlike Lists, a tuple can mix types. The type of the tuple depends on the types of its elements. Thus a
 
 `(Int, String) `

--- a/lists.md
+++ b/lists.md
@@ -18,7 +18,7 @@ Lists are a fundamental data of functional programming languages. In statically 
 
 ---
 
-##List Extras
+## List Extras
 
 Many of the solutions to problems in this book can take advantage of some commonly used list manipulation functions. The Elm community created the List.Extra module which is well worth your time to peruse. These functions will be familiar to experienced functional programmers, especially Haskell programmers.
 

--- a/lt/maybe,_just,_nothing.md
+++ b/lt/maybe,_just,_nothing.md
@@ -10,7 +10,7 @@ Type Maybe a = Just a | Nothing.
 We see ```Maybe``` is a union type. A ```Maybe``` must either  be a  ```Just``` something or a ```Nothing```. Also it is parameterized, so we can use it for lists of any type.
 
 
-##Problems returning Maybe
+## Problems returning Maybe
 
 [Problem 1](../p/p01.md) - Get last element of a list.
 

--- a/lt/recursion_on_lists.md
+++ b/lt/recursion_on_lists.md
@@ -1,6 +1,6 @@
 # Recursion on Lists
 
-##Example 1
+## Example 1
 
 Let's use [Problem 4](/../p/p04.md) as a simple example of recursing  through a list. 
 
@@ -18,7 +18,7 @@ When recursing over a list's items you will often use the ```x :: xs``` cons con
 
 To avoid an infinite loop, there must be a case where the function is not called, bringing an end to the recusion stack. Frequently, as in this example, that is the empty list.
 
-##Example 2
+## Example 2
 
 Frequently when recursing over a list, you will build up a new list to return as a result. [Problem 5](../p/p05.md "Problem 5") builds a new list in reverse order from it's input. 
 

--- a/map.md
+++ b/map.md
@@ -2,13 +2,13 @@
 
 ```List.map``` applies a provided function to all elements of a list. 
 
-##Example
+## Example
 ```elm
 List.map negate [1, 2, -3] == [-1, -2, 3]
 List.map abs [1, 2, -3] == [1, 2, 3]
 ```
 
-##Problems to solve using List.map
+## Problems to solve using List.map
 
 [Problem 4](../p/p04.md) - Count the elements using map. Hint: after passing a simple function to map, you can get the count by calling ```List.sum```. 
 

--- a/p/e01.md
+++ b/p/e01.md
@@ -1,11 +1,11 @@
 # Extra #1 - dropWhile
 Drop items from the start of a list until an item does not satisfy criteria specified by a function.
 
-##Example
+## Example
 ```
 dropWhile isEven [2, 4, 5, 6, 7] == [5, 6, 7]
 ```
-##Unit Test
+## Unit Test
 ```elm
 import Html 
 import List
@@ -41,8 +41,8 @@ isEven x = x % 2 == 0
 isOdd x = x % 2 /= 0
             
 ```
-##Hints
+## Hints
 Recurse!
 
-##Solutions
+## Solutions
 [Solutions](../s/e01.md)

--- a/p/e02.md
+++ b/p/e02.md
@@ -1,11 +1,11 @@
 # Extra #2 - takeWhile
 Keep elements from the start of a list while they satisfy a condition.
 
-##Example
+## Example
 ```
 takeWhile isEven [2, 4, 6, 7, 8] == [2, 4, 6]
 ```
-##Unit Test
+## Unit Test
 ```elm
 import Html exposing (text)
 import List
@@ -45,8 +45,8 @@ isOdd x =
     x % 2 /= 0
     
 ```
-##Hints
+## Hints
 1. Recurse!
 
-##Solutions
+## Solutions
 [Solutions](../s/e02.md)

--- a/p/e02.md
+++ b/p/e02.md
@@ -3,7 +3,7 @@ Keep elements from the start of a list while they satisfy a condition.
 
 ##Example
 ```
-dropWhile isEven [2, 4, 5, 6, 7] == [5, 6, 7]
+takeWhile isEven [2, 4, 6, 7, 8] == [2, 4, 6]
 ```
 ##Unit Test
 ```elm

--- a/p/p01.md
+++ b/p/p01.md
@@ -2,7 +2,7 @@
 
 Write a function ```last``` that returns the last element of a list. An empty list doesn't have a last element, therefore ```last``` must return a Maybe. 
 
-##Example
+## Example
 Cut and paste the following code into the online compiler [http://elm-lang.org/try](http://elm-lang.org/try). Insert your implementation of ```last``` and test.
 
 ```elm

--- a/p/p02.md
+++ b/p/p02.md
@@ -2,7 +2,7 @@
 
 Implement the function ```penultimate``` to find the next to last element of a list.
 
-##Example
+## Example
 ```elm
   penultimate [1, 2, 3, 4] == Just 3
 ```
@@ -57,5 +57,5 @@ Here are a hints for two different solutions.
 1. Use recursion.
 2. What can you do to a list to make [List.head](http://package.elm-lang.org/packages/elm-lang/core/1.0.0/List#head) solve this problem? 
 
-##Solutions 
+## Solutions 
 [Solutions](../s/s02.md)

--- a/p/p03.md
+++ b/p/p03.md
@@ -1,7 +1,7 @@
 # Problem 3
 Implement the function ```elementAt``` to return the n-th element of a list. The index is 1-relative, that is, the first element is at index 1.  
 
-##Example:
+## Example:
 ```elm
 elementAt [3, 4, 5, 6] 2 == Just 4
 ```
@@ -51,7 +51,7 @@ test =
 1. Use recursion.
 2. Use ```List.drop```.
 
-##Solutions
+## Solutions
 [Solutions](../s/s03.md)
 
    

--- a/p/p04.md
+++ b/p/p04.md
@@ -1,7 +1,7 @@
 # Problem 4
 Elm provides the function ```List.length```. See if you can implement it yourself.
 
-##Example
+## Example
 ```
 countElements [1, 2, 3, 4, 3, 2, 1] == 7
 ```

--- a/p/p05.md
+++ b/p/p05.md
@@ -1,7 +1,7 @@
 # Problem 5
 Elm provides the function ```List.reverse``` to reverse the order of elements in a list. See if you can implement it.
 
-##Example
+## Example
 ```
 myReverse [1..4] == [4, 3, 2, 1]
 ```

--- a/p/p06.md
+++ b/p/p06.md
@@ -1,12 +1,12 @@
 # Problem 6
 Determine if a list is a palindrome, that is, the list is identical when read forward or backward.
 
-##Example
+## Example
 ```elm
 isPalindrome [1,2,3,2,1] == True
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List

--- a/p/p07.md
+++ b/p/p07.md
@@ -5,7 +5,7 @@ Flatten a nested lists into a single list. Because Lists in Elm are homogeneous 
 type NestedList a = Elem a | List [NestedList a]
 ```
 
-##Example
+## Example
 ```elm
 nl1 =
     SubList
@@ -23,7 +23,7 @@ nl1 =
 flatten nl1 == List.range 1 9
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 
 import Html

--- a/p/p08.md
+++ b/p/p08.md
@@ -6,7 +6,7 @@ Write a function to remove consecutive duplicates of list elements.
 noDupes [1, 1, 2, 2, 3, 3, 3, 4, 5, 4, 4, 4, 4]
     == [1, 2, 3, 4, 5, 4]
 ```
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List

--- a/p/p09.md
+++ b/p/p09.md
@@ -2,7 +2,7 @@
 
 Convert a list to a list of lists where repeated elements of the source list are packed into sublists. Elements that are not repeated should be placed in a one element sublist.
 
-##Example
+## Example
 ```
 pack [1,1,1,2,3,3,3,4,4,4,4,5,6,6] ==
     [ [1,1,1]
@@ -14,7 +14,7 @@ pack [1,1,1,2,3,3,3,4,4,4,4,5,6,6] ==
     ]
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List

--- a/p/p10.md
+++ b/p/p10.md
@@ -24,7 +24,7 @@ lists =
 runLengths lists == tuples
 ```
 
-##Unit Test
+## Unit Test
 
 ```elm
 import Html

--- a/p/p11.md
+++ b/p/p11.md
@@ -5,7 +5,7 @@ Write a function to run length encode a list, but instead of using a tuple as in
 type RleCode a = Run Int a | Single a
 ```
 
-##Example
+## Example
 
 ```elm
 rleEncode [1, 1, 1, 1, 2, 3, 3, 4, 5, 5, 5, 5, 5, 5] 

--- a/p/p12.md
+++ b/p/p12.md
@@ -54,5 +54,5 @@ test =
 ## Hints
 1. Check out [List.concatMap](http://package.elm-lang.org/packages/elm-lang/core/4.0.3/List#concatMap). 
 
-##Solutions 
+## Solutions 
 [Solutions](../s/s12.md)

--- a/p/p14.md
+++ b/p/p14.md
@@ -2,7 +2,7 @@
 
 Duplicate each element of a list.
 
-##Example
+## Example
 ```
 duplicate [1, 2, 3, 5, 8, 8] == [1, 1, 2, 2, 3, 3, 5, 5, 8, 8, 8, 8]
 ```
@@ -46,5 +46,5 @@ test =
 1. Recurse with cons. 
 
 
-##Solutions 
+## Solutions 
 [Solutions](../s/s14.md)

--- a/p/p15.md
+++ b/p/p15.md
@@ -2,7 +2,7 @@
 
 Repeat each element of a list a given number of times.
 
-##Example
+## Example
 ```
 repeatElements 3 [1, 2, 3, 3] == [1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 3]
 ```
@@ -52,5 +52,5 @@ test =
 1. Do I need to *repeat* myself? "Recurse!"
 2. Another solution uses List.concatMap
 3. Fold!
-##Solutions 
+## Solutions 
 [Solutions](../s/s15.md)

--- a/p/p16.md
+++ b/p/p16.md
@@ -2,7 +2,7 @@
 
 Drop every nth element from a list.
 
-##Example
+## Example
 ```
 dropNth (List.range 1 10) 3 == [1, 2, 4, 5, 7, 8, 10]
 ```
@@ -56,5 +56,5 @@ test =
 1. This is why [Problem 20](p20.md) goes in front of Problem 16; add recursion, and more checking of your inputs.
 
 
-##Solutions 
+## Solutions 
 [Solutions](../s/s16.md)

--- a/p/p17.md
+++ b/p/p17.md
@@ -2,12 +2,12 @@
 
 Split a list into two lists. The length of the first part is specified by the caller.
 
-##Example
+## Example
 ```
 split (List.range 1 10) 3 == ([1, 2, 3], [4, 5, 6, 7, 8, 9, 10])
 ```
 
-##Unit Test
+## Unit Test
 ```
 import Html exposing (text)
 import List 

--- a/p/p19.md
+++ b/p/p19.md
@@ -2,7 +2,7 @@
 
 Rotate a list ```n``` places to the left (negative values will rotate to the right). Allow rotations greater than the list length. 
 
-##Example
+## Example
 ```
 [rotate 3 (List.range 1 10), rotate 11 (List.range 1 10) ] == 
   [ [4, 5, 6, 7, 8, 9, 10, 1, 2, 3]
@@ -52,5 +52,5 @@ test =
 
 ## Hints
 1. Take and ...
-##Solutions 
+## Solutions 
 [Solutions](../s/s19.md)

--- a/p/p21.md
+++ b/p/p21.md
@@ -2,7 +2,7 @@
 
 Insert an element at a given position into a list. Treat the first position as index 1. 
 
-##Example
+## Example
 ```elm 
 insertAt 2 'l' ['E', 'm'] == ['E', 'l', 'm']
 ```
@@ -54,5 +54,5 @@ test =
 3. Recursion can solve this. 
 
 
-##Solutions 
+## Solutions 
 [Solutions](../s/s21.md)

--- a/p/p22.md
+++ b/p/p22.md
@@ -2,7 +2,7 @@
 
 Create a list containing all integers within a given range, inclusively, allow for reverse order
 
-##Example
+## Example
 ```elm
 range 8 4 == [8, 7, 6, 5, 4]
 ```
@@ -51,5 +51,5 @@ test =
 2. Range only varies from the range operator (..) by allowing reverse order.
 
 
-##Solutions 
+## Solutions 
 [Solutions](../s/s22.md)

--- a/p/p24.md
+++ b/p/p24.md
@@ -102,5 +102,5 @@ view model =
 1. A very simple solution is possible using the solution from [Problem 23](p23.md).
 
 
-##Solutions 
+## Solutions 
 [Solutions](../s/s24.md)

--- a/p/p28a.md
+++ b/p/p28a.md
@@ -9,7 +9,7 @@ When you need other sort logic pass a function to ```List.sortBy```.
 
 Sort a list of list by the length of the lists. The order of sublists of the same size is undefined. 
 
-##Example
+## Example
 ```elm
 lists = [[1],[2],[3,4,5],[6,7,8],[2,3],[4,5],[6,7,8,9,0]] 
 map List.length (sortByListLengths lists) == [1, 1, 2, 2, 3, 3, 5]
@@ -67,5 +67,5 @@ test =
 1. If you use ```List.sortBy```, you need to pass a function to it. Hmm, a function that returns a comparable value based on a list length? What could it possibly be called?
 
 
-##Solution
+## Solution
 [Solution](../s/s28a.md)

--- a/p/p28b.md
+++ b/p/p28b.md
@@ -2,7 +2,7 @@
 
 Sort a list according to the frequency of the sublist length. Place lists with rare lengths first, those with more frequent lengths come later. If the frequency of two or more sublists are equal the any order is acceptable. 
 
-##Example
+## Example
 ```elm
 (List.map List.length 
   <| sortByLengthFrequency 
@@ -70,5 +70,5 @@ test =
 
 
 
-##Solutions 
+## Solutions 
 [Solutions](../s/s28b.md)

--- a/p/p31.md
+++ b/p/p31.md
@@ -44,7 +44,7 @@ test =
 
 ```
 
-##Hints
+## Hints
 1. Try the [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes). ```List.filter``` will come in handy.
 
 ## Solutions

--- a/p/p32.md
+++ b/p/p32.md
@@ -54,7 +54,7 @@ test =
 (..) start end =
     List.range start end
 ```
-##Hints
+## Hints
 1. This is easy!
 
 [Solutions](../s/s32.md)

--- a/p/p34.md
+++ b/p/p34.md
@@ -3,7 +3,7 @@ Calculate Euler's totient function phi(m).
 
 Euler's totient function phi(m) is defined as the number of positive integers ```r (1 <= r < m)``` that are coprime with ```m```.
 
-##Example 
+## Example 
 >  let m = 10   
 >  then coprimes of m are 1,3,7,9   
 >  and totient of m is 4

--- a/p/p36.md
+++ b/p/p36.md
@@ -2,12 +2,12 @@
 
 Construct a list containing the prime factors and their multiplicity for a given integer.
 
-##Example
+## Example
 ```
 primeFactorsM 315 = [(3, 2), (5,1), (7,1)]
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -45,10 +45,10 @@ test =
         , ( primeFactorsM 26028, [ ( 2, 2 ), ( 3, 3 ), ( 241, 1 ) ] )
         ]
 ```
-##Hints
+## Hints
 1. Combine code from problems [9](problem_9.md), [10](problem_10.md) and [35](problem_35.md)
 
-##Solutions
+## Solutions
 [Solutions](../s/s36.md)
 
 

--- a/p/p39.md
+++ b/p/p39.md
@@ -50,7 +50,7 @@ test =
   
 ```
 
-##Hints
+## Hints
 1. Modify the solution from [Problem 31](p31.md). 
 
 ## Solutions

--- a/p/p40.md
+++ b/p/p40.md
@@ -4,7 +4,7 @@
 
 Return two prime numbers that sum up to a given even integer.
 
-##Example
+## Example
 ```elm
 goldbach 100 == (29, 71)
 ```

--- a/p/p41.md
+++ b/p/p41.md
@@ -40,8 +40,8 @@ test =
         
 ```
 
-##Hints
+## Hints
 1. Use the solution from [Problem 40](p40.md). 
 
-##Solutions
+## Solutions
 [Solutions](../s/s41.md)

--- a/p/p46.md
+++ b/p/p46.md
@@ -29,7 +29,7 @@ Define a function to show a truth table for a logical expression.
 ```    
 truthTable : (Bool -> Bool -> Bool) -> List (Bool, Bool, Bool) 
 ``` 
-##Unit Test
+## Unit Test
 ```elm
 import Html exposing (text)
 import List exposing (map)
@@ -174,6 +174,6 @@ test =
 
 ```
 
-##Solutions
+## Solutions
 [Solutions](../s/s46.md) 
 

--- a/p/p47.md
+++ b/p/p47.md
@@ -13,7 +13,7 @@ Create custom infix operators for the logical functions from Problem 46. Use the
 
 Precedence and associativity of custom operators can be set with the keywords infixl, infix, and infixr. See http://elm-lang.org/blog/announce/0.10#infix-operators. 
 
-##Example
+## Example
 ```elm 
 truthTable (\a b -> a .& ( a .| b)) == 
 	    [ (True, True, True)
@@ -29,7 +29,7 @@ truthTable (\a b -> a .& ( a .| b)) ==
 	    --}
 ```
 
-##Unit Test
+## Unit Test
 
 ```elm     
 import Html exposing (text)
@@ -105,5 +105,5 @@ test =
             ]  
 ```
 
-##Solutions
+## Solutions
 [Solutions](../s/s47.md)

--- a/p/p49.md
+++ b/p/p49.md
@@ -1,6 +1,6 @@
 # Problem 49
 The [Gray Code](http://mathworld.wolfram.com/GrayCode.html) is a binary numbering system used in error correction system. It can be generated for different bit sizes using a *reflecting* pattern. To generate a two-bit code, take the single bit Gray code 0, 1. Write it forwards, then backwards: 0, 1, 1, 0. Prepend 0s to the first half and 1s to the second half: 00, 01, 11, 10. To generate a 3-bit code, write 00, 01, 11, 10, 10, 11, 01, 00 to obtain: 000, 001, 011, 010, 110, 111, 101, 100.
-##Example
+## Example
 ```elm
 grayCode 3 == [[0,0,0], [0,0,1], [0,1,1], [0,1,0], [1,1,0], [1,1,1], [1,0,1], [1,0,0]]
 ```

--- a/p/p50a.md
+++ b/p/p50a.md
@@ -1,12 +1,12 @@
 #Problem 50a - Huffman Encoding 
 Huffman coding uses variable bit length codes to efficiently encode data by giving the frequently found values short codes and rarely used values longer codes. The first step in Huffman encoding is to determine the frequency of every value in the input data. 
 
-##Example
+## Example
 ```elm 
 freqs [1, 20, 20, 3, 3, 3, 3] == [(1, 1), (2, 20), (4, 3)]
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List

--- a/p/p50b.md
+++ b/p/p50b.md
@@ -4,13 +4,13 @@ Huffman coding uses variable bit length codes to efficiently encode data. In [Pr
 You'll need a binary tree to build the codes. You should complete [Problems 54 through 61](../binary-trees.md) before attempting this problem.
 
 
-##Example
+## Example
 ```elm 
 huffman [('a',45),('b',13),('c',12),('d',16),('e',9),('f',5)] == 
 [('a',"0"),('b',"101"),('c',"100"),('d',"111"),('e',"1101"),('f',"1100")]
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List

--- a/p/p55.md
+++ b/p/p55.md
@@ -14,7 +14,7 @@ balancedTree 3 ==
 ```
 
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -97,5 +97,5 @@ count tree =
   
 ```
 
-##Solutions
+## Solutions
 [Solutions](../s/s55.md)

--- a/p/p56.md
+++ b/p/p56.md
@@ -2,7 +2,7 @@
 
 We call a binary tree symmetric if you can draw a vertical line through the root node and the right subtree is the mirror image of the left subtree. Write a function to check if a binary tree is structurally symmetric (ignore the node values).
 
-##Example
+## Example
 
 ```elm
 tree1 = 
@@ -22,7 +22,7 @@ isSymmetric tree1 == True
 
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -106,9 +106,9 @@ count tree =
         Node n left right ->
             1 + (count left) + (count right)
 ```
-##Hint
+## Hint
 1. Look in the mirror (recursively). 
 
 
-##Solutions
+## Solutions
 [Solutions](../s/s56.md) 

--- a/p/p57.md
+++ b/p/p57.md
@@ -2,7 +2,7 @@
 
 Build a [binary search tree](http://www.tutorialspoint.com/data_structures_algorithms/binary_search_tree.htm) from a list. Place lower values the right. By definition, duplicate values are omitted. 
 
-##Example 
+## Example 
 ```elm
 toBSTree [6, 2, 4, 20, 1, 11, 12, 14] == 
             Node 6 
@@ -18,7 +18,7 @@ toBSTree [6, 2, 4, 20, 1, 11, 12, 14] ==
                 Empty)
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -67,8 +67,8 @@ test =
         ]
 ```
 
-##Hints
+## Hints
 1. The solution to [Problem 55](p55.md) can be easily modified to solve this problem. 
 
-##Solutions
+## Solutions
 [Solutions](../s/s57.md)

--- a/p/p61a.md
+++ b/p/p61a.md
@@ -2,7 +2,7 @@
 
 Count the leaves of a binary tree. The leaves are the nodes that have empty nodes in both their right and left subtrees.
 
-##Example
+## Example
 ```elm
 tree = Tree 1 (Tree 2 Empty (Tree 4 Empty Empty))
                  (Tree 2 Empty Empty)
@@ -10,7 +10,7 @@ tree = Tree 1 (Tree 2 Empty (Tree 4 Empty Empty))
 countLeaves tree == 2   
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -48,10 +48,10 @@ test =
 
 ```  
 
-##Hints
+## Hints
 1. You should be pretty good at recursion by now. 
 
-##Solutions
+## Solutions
 [Solutions](../s/s61a.md)
 
 

--- a/p/p61b.md
+++ b/p/p61b.md
@@ -2,7 +2,7 @@
 
 Extract the values of the leaves of a binary tree into a list.
 
-##Example
+## Example
 ```elm
 tree = Tree 1 (Tree 2 Empty (Tree 4 Empty Empty))
                  (Tree 2 Empty Empty)
@@ -10,7 +10,7 @@ tree = Tree 1 (Tree 2 Empty (Tree 4 Empty Empty))
 getLeaves aTree == [4, 2]
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -51,10 +51,10 @@ test =
 
 ```  
 
-##Hints
+## Hints
 1. You don't need no stinking hints! 
 
-##Solutions
+## Solutions
 [Solutions](../s/s61b.md)
 
 

--- a/p/p62a.md
+++ b/p/p62a.md
@@ -2,7 +2,7 @@
 
 Count internal nodes (those that have non-empty subtrees) of a binary tree.
 
-##Example
+## Example
 ```elm
 tree = Tree 'a' (Tree 'b' Empty (Tree 'c' Empty Empty))
                  (Tree 'd' Empty (Tree 'e' Empty Empty))
@@ -10,7 +10,7 @@ tree = Tree 'a' (Tree 'b' Empty (Tree 'c' Empty Empty))
 countInternals tree == 3
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -49,10 +49,10 @@ test =
         
 ```  
 
-##Hints
+## Hints
 1. You don't need no stinking hints! 
 
-##Solutions
+## Solutions
 [Solutions](../s/s62a.md)
 
 

--- a/p/p62b.md
+++ b/p/p62b.md
@@ -2,7 +2,7 @@
 
 Extract the internal nodes (those that have non-empty subtrees) of a binary tree into a list.
 
-##Example
+## Example
 ```elm
 tree = Tree 'a' (Tree 'b' Empty (Tree 'c' Empty Empty))
                  (Tree 'd' Empty (Tree 'e' Empty Empty))
@@ -10,7 +10,7 @@ tree = Tree 'a' (Tree 'b' Empty (Tree 'c' Empty Empty))
 getInternals tree == ['a', 'b', 'd']
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -63,10 +63,10 @@ test =
         
 ```  
 
-##Hints
+## Hints
 1. You don't need no stinking hints! 
 
-##Solutions
+## Solutions
 [Solutions](../s/s62b.md)
 
 

--- a/p/p63.md
+++ b/p/p63.md
@@ -51,8 +51,8 @@ test =
 
 ```
 
-##Hints
+## Hints
 Heaps commonly use complete binary trees as data structures or addressing schemes. We can assign an address to each node in a complete binary tree by enumerating the nodes in level-order starting at the root with number 1. For every node ```X``` with address ```A``` the following holds: The address of ```X```'s left and right successors are ```2*A``` and ```2*A+1```, respectively, if they exist. This fact can be used to elegantly construct a complete binary tree structure.
 
-##Solutions
+## Solutions
 [Solutions](../s/s63.md)

--- a/p/p64.md
+++ b/p/p64.md
@@ -10,7 +10,7 @@ In this layout strategy, the following two rules determine the position:
 
 Write a function to annotate each node of the tree with its position. To solve this problem you will need to traverse the tree. Problems [68a](p68a.md), [68b](p68b.md), and [68c](p68c.md) examine tree traversal.
 
-##Example
+## Example
 ```elm 
 tree64 = 
   Node 'n'
@@ -36,7 +36,7 @@ layout tree64 ==
 
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 
 import Html
@@ -118,7 +118,7 @@ layout64 =
 2. The problem can be solved in a single traversal. You'll probably need nested ```let``` clauses to get the in-order values from subtree traversals. 
 
 
-##Solutions
+## Solutions
 [Solutions](../s/s64.md)
 
 

--- a/p/p65.md
+++ b/p/p65.md
@@ -8,7 +8,7 @@ Find out the rules and write the corresponding function. Hint: On a given level,
 
 To solve this problem you will need to traverse the tree. Problems [68a](p68a.md), [68b](p68b.md), and [68c](p68c.md) examine tree traversal.
 
-##Example
+## Example
 ```elm 
 tree65 = 
     Node 'n'
@@ -33,7 +33,7 @@ layout65 tree65 ==
 
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -109,7 +109,7 @@ layout65 =
 2. Need another hint? The horizontal distance is a function of the depth from the tree from that node and the depth of the left subtree. 
 
 
-##Solutions
+## Solutions
 [Solutions](../s/s65.md)
 
 

--- a/p/p67.md
+++ b/p/p67.md
@@ -7,7 +7,7 @@ a(b(d,e),c(,f(g,)))
 
 Write a function to generate a string representation of a tree. 
 
-##Example
+## Example
 ```elm
 tree = 
     Node 'x' 
@@ -21,7 +21,7 @@ s = "x(y,a(,b))"
 toString tree == "x(y,a(,b))" 
 ```
 
-##Unit test
+## Unit test
 
 ```elm
 import Html
@@ -89,9 +89,9 @@ tInt =
 
 ```
 
-##Hints
+## Hints
 1. Solve the problem for just one Tree type first, ```Tree Int``` for example. 
 
 
-##Solutions
+## Solutions
 [Solutions](../s/s67a.md)

--- a/p/p67bmd.md
+++ b/p/p67bmd.md
@@ -6,7 +6,7 @@ Consider a string representation of a tree with a single character naming each n
 
 Write a function to generate a tree from its string representation created in [Problem 67a](p67a.md). 
 
-##Example
+## Example
 ```elm
 toTree "x(y,a(,b))" ==  
     Node 'x' 
@@ -16,7 +16,7 @@ toTree "x(y,a(,b))" ==
             (Node 'b' Empty Empty))
 ```
 
-##Unit test
+## Unit test
 
 ```elm
 import Html
@@ -87,9 +87,9 @@ t4 =
 
 ```
 
-##Hints
+## Hints
 1. Solve the problem for just one Tree type first, ```Tree Int``` for example. 
 
 
-##Solutions
+## Solutions
 [Solutions](../s/s67b.md)

--- a/p/p68a.md
+++ b/p/p68a.md
@@ -9,7 +9,7 @@ There are three commonly used traversal forms, pre-order, in-order and post-orde
 Write a function to traverse a tree and return the values in a list in pre-order.
 
 
-##Example
+## Example
 ```elm
 tree67 = 
     Node 'a'
@@ -25,7 +25,7 @@ tree67 =
 preorder tree67 == ['a', 'b', 'd', 'e', 'c', 'f', 'g'] 
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List

--- a/p/p68b.md
+++ b/p/p68b.md
@@ -3,7 +3,7 @@
 Write a function to traverse a tree and return the values in a list in in-order.
 
 
-##Example
+## Example
 ```elm
 tree67 = 
     Node 'a'
@@ -19,7 +19,7 @@ tree67 =
 inorder tree67 == ['d', 'b', 'e', 'a', 'c', 'g', 'f'] 
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 \import Html
 import List

--- a/p/p68c.md
+++ b/p/p68c.md
@@ -3,7 +3,7 @@
 Write a function to traverse a tree and return the values in a list in post-order.
 
 
-##Example
+## Example
 ```elm
 tree67 = 
     Node 'a'
@@ -19,7 +19,7 @@ tree67 =
 postorder tree67 == ['d', 'e', 'b', 'g', 'f', 'c', 'a']  
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List

--- a/p/p69.md
+++ b/p/p69.md
@@ -6,13 +6,13 @@ a) Write a function to create the dot-string representation of a tree.
 
 b) Write a function to build a tree from a dot-string.
 
-##Example
+## Example
 ```elm
 tree69 = "abd..e..c.fg..."
 tree69 == treeToDot <| dotToTree tree69
 ```
    
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -101,10 +101,10 @@ tree69b =
 
 ```
 
-##Hints
+## Hints
 1. ```String.uncons``` and ```String.fromChar``` may come in handy.
 2. To convert from string to tree recurse in preorder with a function that returns two values, the tree value and the unused portion of the string. 
 
 
-##Solution
+## Solution
 [Solution](../s/s69.md)

--- a/p/p70.md
+++ b/p/p70.md
@@ -46,5 +46,5 @@ test =
       
 ```
 
-##Solution
+## Solution
 [Solution](../s/s70.md)

--- a/p/p70b.md
+++ b/p/p70b.md
@@ -10,7 +10,7 @@ a) Write a function to convert a multiway tree to a string representation.
 
 b) Write a function to convert a string representation to a multiway tree. 
 
-##Example
+## Example
 ```elm
 type MTree a = MNode a (List (MTree a))
 
@@ -25,7 +25,7 @@ s70 = "afg^^c^bd^e^^^"
 s70 == treeToString <| stringToTree s70
 ```
    
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -80,12 +80,12 @@ mtree70 = MNode 'a'
           ]
 ```
 
-##Hints
+## Hints
 1. This problem is similar to [Problem 69](p69.md).  
 2. Traverse the tree in pre-order with a function that returns two values, the tree value and the unused portion of the string. 
 3. Treating the root node differently that the rest of the tree may result in simpler functions.
 4. ```List.intersperse```, ```List.fromChar```, ```List.cons``` and ```List.uncons``` may come in handy
 
 
-##Solution
+## Solution
 [Solution](../s/s70b.md)

--- a/p/p71.md
+++ b/p/p71.md
@@ -59,5 +59,5 @@ test4 = MNode 'a' [ MNode 'f' [], MNode 'g' [], MNode 'g' [], MNode 'g' [] ]
 test5 = MNode '1' [ MNode '2' [ MNode '3' [ MNode '4' [ test4 ] ] ] ]
 
 ```
-##Solution
+## Solution
 [Solution](../s/s71.md)

--- a/p/p72.md
+++ b/p/p72.md
@@ -1,7 +1,7 @@
 # Problem 72
 Collect the nodes of a multiway tree in depth-first order. 
 
-##Example
+## Example
 
 ![](../i/p70.gif)
 
@@ -66,7 +66,7 @@ test5 =
 
 ```
 
-##Hint
+## Hint
 1. Depth-first again?
 2. List.concatMap could make the solution very concise.
 

--- a/p/p80a.md
+++ b/p/p80a.md
@@ -2,7 +2,7 @@
 
 Convert from a graph from graph-term to adjacency-list representation. (See [Graphs](../graphs.md) for details on these formats.)
 
-##Example
+## Example
 ![](../i/graph1.gif)
 
 ```elm
@@ -22,7 +22,7 @@ adjList80 =
 adjList80 == graphToAdjList graph80
 
 ```
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -73,9 +73,9 @@ adjList80 =
 
 ```
 
-##Hints
+## Hints
 1. ```Set.fromList``` and ```Set.toList``` may come in handy. 
 
 
-##Solution
+## Solution
 [Solution](../s/s80a.md)

--- a/p/p80b.md
+++ b/p/p80b.md
@@ -2,7 +2,7 @@
 
 Convert from a graph from adjacency-list to graph-term representation. (See [Graphs](../graphs.md) for details on these formats.)
 
-##Example
+## Example
 ![](../i/graph1.gif)
 
 ```elm
@@ -22,7 +22,7 @@ adjList80 =
 graph80 == adjListToGraph adjList80
 
 ```
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -74,5 +74,5 @@ adjList80 =
 ```
 
 
-##Solution
+## Solution
 [Solution](../s/s80b.md)

--- a/p/p81.md
+++ b/p/p81.md
@@ -2,7 +2,7 @@
 
 Write a function that, given two nodes a graph, returns all the acyclic paths between the two nodes.
 
-##Example
+## Example
 
 ```elm
 paths : (Graph a) a a -> List (List a)
@@ -12,7 +12,7 @@ g81 = (['b','c','d','f','g','h','k'], [('b','c'),('b','f'),('c','f'),('f','k'),(
 paths g81 'k' 'b' == [['k', 'f', 'c', 'b'], ['k', 'f', 'b']]
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List

--- a/p/p84.md
+++ b/p/p84.md
@@ -2,7 +2,7 @@
 
 Use [Prim's algorithm](http://www.tutorialspoint.com/data_structures_algorithms/prims_spanning_tree_algorithm.htm) to find the minimal spanning tree of a [connected](https://en.wikipedia.org/wiki/Connectivity_(graph_theory), [edge-weighted](http://mathworld.wolfram.com/WeightedGraph.html) graph. 
 
-##Example
+## Example
 Example graph with weighted edges.
 
 ![](graph81.gif)
@@ -18,7 +18,7 @@ graph84 = ( [ 'b', 'c', 'd', 'f', 'g', 'h', 'k' ],
 
 prim 'f' graph84 == ([ 'b', 'c', 'd', 'f', 'g', 'h', 'k' ], [('b','f',8),('b','c',5),('b','g',9),('g','h',15),('f','k',17)]) 
 ```
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -109,5 +109,5 @@ prim84 = ( [ 'b', 'c', 'f', 'g', 'h', 'k' ]
          )
 ```
 
-##Solution
+## Solution
 [Solution](../s/s84.md)

--- a/p/p86.md
+++ b/p/p86.md
@@ -4,7 +4,7 @@ Set the degree of a every node in a graph. The degree  of a node is the number o
 
 We will use the degree to color a graph with the minimum number of colors. We now define a node type to have a value, degree and color.
 
-##Example
+## Example
 ```elm
 {-| A node has a value, degree and a color 
 -}
@@ -49,7 +49,7 @@ g80d =
 degree g80 = g80d 
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -203,5 +203,5 @@ loopsAndParallels =
         
 ```
 
-##Solution
+## Solution
 [Solution](../s/s86a.md)

--- a/p/p86b.md
+++ b/p/p86b.md
@@ -3,7 +3,7 @@
 Use the [Welsh-Powell algorithm](http://graphstream-project.org/doc/Algorithms/Welsh-Powell/) to color a graph with the minimum number of colors.
 
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -153,5 +153,5 @@ graph84 =
     )
 ```
 
-##Solution
+## Solution
 [Solution](../s/s86b.md)

--- a/p/p87.md
+++ b/p/p87.md
@@ -2,7 +2,7 @@
 
 Extract nodes from a graph into a list in [depth-first order](https://en.wikipedia.org/wiki/Depth-first_search#Example), without repeating any nodes. Search the children of each node in order from lowest to highest.  
 
-##Example
+## Example
 ```elm
 
 g87 = ([1,2,3,4,5,6,7], [(1,2),(2,3),(1,4),(3,4),(5,2),(5,4),(6,7)])
@@ -10,7 +10,7 @@ g87 = ([1,2,3,4,5,6,7], [(1,2),(2,3),(1,4),(3,4),(5,2),(5,4),(6,7)])
 depthFirst g87 == [1, 2, 3, 4, 5]
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -123,5 +123,5 @@ graph87 =
 #Hint
 1. Track of all nodes you have already visited as you traverse the graph to avoid cyclic paths. 
 
-##Solution
+## Solution
 [Solution](../s/s87.md)

--- a/p/p87b.md
+++ b/p/p87b.md
@@ -2,14 +2,14 @@
 
 Extract nodes from a graph into a list in [breadth-first order](https://en.wikipedia.org/wiki/Breadth-first_search), without repeating any nodes.
 
-##Example
+## Example
 ![](graph87b.png)
 ```elm
 
 breadthFirst 'c' graph == ['c', 'b', 'f', 'g', 'k', 'h']
 ```
 
-##Unit Test
+## Unit Test
 ```elm
 import Html
 import List
@@ -125,5 +125,5 @@ graph87 =
 #Hint
 1. A small modification to the [depth-first graph](p87.md) search can resolve solve this problem.
 
-##Solution
+## Solution
 [Solution](../s/s87b.md)

--- a/p/p88.md
+++ b/p/p88.md
@@ -2,7 +2,7 @@
 
 Split a graph into its connected components.
 
-##Example
+## Example
 ```
 connected ([1,2,3,4,5,6,7], [(1,2),(2,3),(1,4),(3,4),(5,2),(5,4),(6,7)])
   == [[1,2,3,4,5][6,7]]

--- a/p/p91.md
+++ b/p/p91.md
@@ -28,5 +28,5 @@ Possible result:
 (6,7),(8,8),(7,6),(8,4),(7,2),(5,1),(3,2),(1,1)]
 ```
 
-##Solution
+## Solution
 A solution is [offered on Rosetta Code](http://rosettacode.org/wiki/Knight%27s_tour#Elm) and can be [viewed here](http://dc25.github.io/knightsTourElm/).

--- a/p/p97.md
+++ b/p/p97.md
@@ -26,7 +26,7 @@ Problem statement                 Solution
 
 Write a program to solve a sudoku.
 
-##Hint
+## Hint
 1. You can model Sudoku puzzle as a graph with 81 nodes, one for each cell. Each node has an edge to the other  nodes in its row, its column and its square. 
 2. What graph algorithm can you use to solve the Sudoku? 
 3. [A solution described](http://www.codeproject.com/Articles/801268/A-Sudoku-Solver-using-Graph-Coloring) by [Mustafa Eissa](http://www.codeproject.com/script/Membership/View.aspx?mid=5805426).

--- a/passing_functions.md
+++ b/passing_functions.md
@@ -2,7 +2,7 @@
 
 In many programming languages functions are first-class. This means that a function is a value that can be passed as a argument to other functions. Functions are as fundamental as integers, characters, booleans and  strings. The problems below demonstrate functions in the Elm core that take functions are arguments. Likewise, you will often create your own functions that take functions are arguments. 
 
-##Functions that take functions
+## Functions that take functions
 
 [Problem 28a](p/p28a.md) - Use ```List.sortBy``` to sort a list.
 

--- a/s/s01.md
+++ b/s/s01.md
@@ -1,6 +1,6 @@
 # Problem 1 Solutions
 
-##Solution 1
+## Solution 1
 Recursive search for the last element
 
 ```
@@ -11,7 +11,7 @@ last xs =
     [a] -> Just a
     y::ys -> last ys
 ```
-##Solution 2
+## Solution 2
 Reverse and take the head.
 ```
 last : List a -> Maybe a
@@ -19,7 +19,7 @@ last xs =
    List.reverse xs |> List.head
 ```
 
-##Solution 3
+## Solution 3
 [Point-free style](https://en.wikipedia.org/wiki/Tacit_programming), reverse and take the head.
 ```
 last : List a -> Maybe a
@@ -27,7 +27,7 @@ last =
    List.reverse >> List.head
 ```
 
-##Solution 4
+## Solution 4
 Use `List.foldl`.
 ```elm
 last : List a -> Maybe a

--- a/s/s02.md
+++ b/s/s02.md
@@ -1,6 +1,6 @@
 # Problem 2 Solutions
 
-###Solution 1:
+### Solution 1:
 Recursive search for the last element
 
 ```
@@ -13,7 +13,7 @@ penultimate list =
     y::ys -> penultimate ys
 
 ```
-###Solution 2: 
+### Solution 2: 
 Reverse the list and take the head of the tail.
 ```
 penultimate : List a -> Maybe a
@@ -23,7 +23,7 @@ penultimate list =
     y::ys -> List.head ys
 
 ```
-###Solution 3: 
+### Solution 3: 
 Reverse the list, drop one and take the head. 
 ```
 penultimate : List a -> Maybe a

--- a/s/s04.md
+++ b/s/s04.md
@@ -1,6 +1,6 @@
 # Problem 4 Solutions
 
-###Solution #1:
+### Solution #1:
 Recursive solution
 
 ```elm
@@ -11,7 +11,7 @@ countElements list =
         _ :: ys -> 1 + countElements ys
 ```
 
-###Solution #2:
+### Solution #2:
 
 Recursive solution with accumulator
 
@@ -27,7 +27,7 @@ countElements list =
         countElements_acc list 0
 ```
 
-###Solution #3:
+### Solution #3:
 
 Use foldl. This is how Elm core defines ```List.length```.
 
@@ -37,7 +37,7 @@ countElements list = List.foldl (\_ n -> n + 1) 0 list
 
 ```
 
-###Solution #4:
+### Solution #4:
 
 Convert elements to 1 using ```List.map``` and ```List.sum```.
 

--- a/s/s05.md
+++ b/s/s05.md
@@ -1,7 +1,7 @@
 # Problem 5 Solutions
 
 
-##Solution 1 - fold
+## Solution 1 - fold
 
 ```
 myReverse : List a -> List a

--- a/s/s06.md
+++ b/s/s06.md
@@ -7,7 +7,7 @@ isPalindrome xs =
     List.reverse xs == xs
 ```
 
-###Solution #2:
+### Solution #2:
 This makes half as many compares. 
 ```
 isPalindrome : List a -> Bool

--- a/s/s08.md
+++ b/s/s08.md
@@ -20,7 +20,7 @@ noDupCons x xs =
 
 ```
 
-###Solution #2:
+### Solution #2:
 Define a dropWhile function to remove duplicates from the head of a list, then apply it recursively.
 ```
 noDupes : List a -> List a

--- a/s/s09.md
+++ b/s/s09.md
@@ -68,7 +68,7 @@ dropWhile predicate list =
             list
 ```
 
-##Solution 3
+## Solution 3
 Another recursive solution.
 
 ```elm
@@ -89,7 +89,7 @@ pack list =
                     [x]::y
 ```
 
-##Solution 4
+## Solution 4
 Fold it!
 
 ```elm

--- a/s/s12.md
+++ b/s/s12.md
@@ -1,6 +1,6 @@
 # Problem 12 Solutions
 
-###Solution 1
+### Solution 1
 List.concatMap makes this easy. 
 
 ```elm

--- a/s/s18.md
+++ b/s/s18.md
@@ -12,7 +12,7 @@ sublist start end list =
         List.drop s_ list |> List.take (e_ - s_)        
 ```
 
-##Solution 2
+## Solution 2
 Use Array.slice. Note that Array.slice uses negative indices to count from the end of the array. 
 
 ```elm

--- a/s/s28b.md
+++ b/s/s28b.md
@@ -21,7 +21,7 @@ freq xs list =
   )
  ```
  
-##Solution 2
+## Solution 2
 This solution is similar to the first, but replaces the list of length/frequency pairs with a Dict. Lengths are the dictionary keys, and frequencies are the value.
 
 ```elm

--- a/s/s35.md
+++ b/s/s35.md
@@ -1,5 +1,5 @@
 # Problem 35 - Prime factors
-##Solution 1
+## Solution 1
 Use the Sieve of Eratosthenes to find primes, then test each prime from lowest to highest. 
 
 ```elm
@@ -59,7 +59,7 @@ eratos candidates primes =
                 eratos cs (x :: primes)
 
  ```          
-##Solution 2
+## Solution 2
 
 We can optimize the first solution by eliminating primes between n/2 and n. 
 ```elm

--- a/s/s36.md
+++ b/s/s36.md
@@ -1,6 +1,6 @@
 # Problem 36 Solutions
 
-##Solution 1
+## Solution 1
 
 Combine code from problems [9](problem_9.md), [10](problem_10.md) and [35](problem_35.md).
 ```

--- a/s/s46md.md
+++ b/s/s46md.md
@@ -1,6 +1,6 @@
 # Problem 46 Solutions
 
-##Solution 1
+## Solution 1
 
 ```elm
 -- True if and only if a and b are true

--- a/s/s47.md
+++ b/s/s47.md
@@ -1,6 +1,6 @@
 #Problem 47 Solutions
 
-##Solution 1
+## Solution 1
 
 ```elm
 -- True if and only if a and b are true

--- a/s/s49.md
+++ b/s/s49.md
@@ -1,6 +1,6 @@
 #Problem 49 Solutions
 
-###Solution 1
+### Solution 1
 ```elm 
 grayCodes : Int -> List (List Int)
 grayCodes numBits =

--- a/s/s50a.md
+++ b/s/s50a.md
@@ -1,6 +1,6 @@
 #Problem 50a Solutions
 
-###Solution 1
+### Solution 1
 Sort the input, then use the ```pack``` function from [Problem 9](../p/p09.md), ```runLengths``` from [Problem 10](../p/p10.md). Note this requires that the type of the input be a ```comparable```. 
 
 ```elm

--- a/s/s50b.md
+++ b/s/s50b.md
@@ -1,6 +1,6 @@
 #Problem 50b Solution 
 
-##Solution
+## Solution
 ```elm
 
 type Tree a

--- a/s/s55.md
+++ b/s/s55.md
@@ -1,6 +1,6 @@
 #Problem 55
 
-###Solution 1
+### Solution 1
 Use List.foldl, adds one node at a time.
 
 ```elm
@@ -32,7 +32,7 @@ count tree =
             1 + (count left) + (count right)
 ```
 
-###Solution 2
+### Solution 2
 A more efficient solution adds many nodes at once.
 
 ```elm

--- a/s/s57.md
+++ b/s/s57.md
@@ -1,6 +1,6 @@
 # Problem 57 Solutions
 
-###Solution 1
+### Solution 1
 Add one node at a time.
 
 ```elm

--- a/s/s62a.md
+++ b/s/s62a.md
@@ -1,6 +1,6 @@
 # Problem 62a Solutions
 
-##Solution 1
+## Solution 1
 
 ```elm
 countInternals : Tree a -> Int

--- a/s/s64.md
+++ b/s/s64.md
@@ -1,6 +1,6 @@
 #Problem 64 Solutions
 
-##Solution 1
+## Solution 1
 Set the x and y coordinates in a single pass using in-order traversal. 
 
 ```elm
@@ -25,7 +25,7 @@ layoutAux x y tree =
 
 ---
 
-##Solution 2
+## Solution 2
 This solution breaks down the process into three steps, 
 
 * Inserting a coordinate to each node

--- a/s/s68a.md
+++ b/s/s68a.md
@@ -1,6 +1,6 @@
 #Problem 68a
 
-##Solution 1
+## Solution 1
 
 ```elm
 preorder : Tree a -> List a

--- a/s/s72.md
+++ b/s/s72.md
@@ -2,7 +2,7 @@
 
 Collect the nodes of a multiway tree in depth-first order. 
 
-##Solution
+## Solution
 
 ```elm
 type MTree a

--- a/the_problems.md
+++ b/the_problems.md
@@ -2,7 +2,7 @@
 
 This section presents the 99 problems as they were first presented in 99 Problems in Prolog, arranged in topical groups. Each group will have links to the full problem pages. 
 
-##Problem pages
+## Problem pages
 Each problem page has:
 
 1. Problem statement: Describes problem, and ask you to implement a solution. 


### PR DESCRIPTION
Fix some headings from .md files

They were causing some display issues because the # and the Heading was not separated by an whitespace.