### PR TITLE
Fix missing space in headline "Problem pages"

### DIFF
--- a/the_problems.md
+++ b/the_problems.md
@@ -2,7 +2,7 @@
 
 This section presents the 99 problems as they were first presented in 99 Problems in Prolog, arranged in topical groups. Each group will have links to the full problem pages. 
 
-##Problem pages
+## Problem pages
 Each problem page has:
 
 1. Problem statement: Describes problem, and ask you to implement a solution. 


### PR DESCRIPTION
Fixed a problem where the headline could be rendered incorrect. Cause is a missing space in the markdown headline.

#### Before fix

![image](https://cloud.githubusercontent.com/assets/13085980/25783641/f222290a-335f-11e7-81e9-91636c67a9ae.png)

#### After fix
![image](https://cloud.githubusercontent.com/assets/13085980/25783632/e28358ca-335f-11e7-9915-ed2ab3dcddeb.png)
