### PR TITLE
Somewhat clearer variable names

### DIFF
--- a/s/s10.md
+++ b/s/s10.md
@@ -6,9 +6,10 @@
 
 
 ```elm
+import List exposing (map, length, head)
 runLengths : List (List a) -> List ( Int, a )
 runLengths xss =
-    List.map (\xs -> ( List.length xs, List.head xs )) xss |> removeNothings
+    map (\xs -> ( length xs, head xs )) xss |> removeNothings
 
 
 removeNothings : List ( Int, Maybe a ) -> List ( Int, a )
@@ -17,11 +18,11 @@ removeNothings xs =
         [] ->
             []
 
-        ( c, Nothing ) :: ys ->
-            removeNothings ys
+        ( len, Nothing ) :: rest ->
+            removeNothings rest
 
-        ( c, Just y ) :: ys ->
-            ( c, y ) :: removeNothings ys
+        ( len, Just y ) :: rest ->
+            ( len, y ) :: removeNothings rest
 ```
 
 [Back to Problem 10](../p/p10.md)


### PR DESCRIPTION
Though I would vote for using `sublist` and `list` or `lst` instead of `xs` and `xss`, while in the case of "for xs of xss" using "for sublist of list"...
You'd get:

```
runLengths list =
    map (\sublist -> ( length sublist, head sublist )) list
        |> removeNothings
```